### PR TITLE
Faster unbox if no keys are supplied

### DIFF
--- a/unbox.js
+++ b/unbox.js
@@ -7,6 +7,8 @@ const { DeriveSecret, KeySlot } = require('./util')
 const zerodNonce = Buffer.alloc(na.crypto_secretbox_NONCEBYTES)
 
 function unbox (ciphertext, feed_id, prev_msg_id, trial_keys, opts = {}) {
+  if (trial_keys.length === 0) return null
+
   const {
     maxAttempts = 8
   } = opts
@@ -19,6 +21,8 @@ function unbox (ciphertext, feed_id, prev_msg_id, trial_keys, opts = {}) {
 }
 
 function unboxKey (ciphertext, feed_id, prev_msg_id, trial_keys, opts = {}) {
+  if (trial_keys.length === 0) return null
+  
   const {
     maxAttempts = 8,
     derive = DeriveSecret(feed_id, prev_msg_id)


### PR DESCRIPTION
I noticed that one often ends up with this pattern:

```js
      const trial_group_keys = keystore.author.groupKeys(author)
      let read_key = unboxKey(envelope, feed_id, prev_msg_id, trial_group_keys, {
        maxAttempts: 1,
      })

      if (read_key)
        return decryptBox2Msg(envelope, feed_id, prev_msg_id, read_key)

    const trial_dm_keys = [
      keystore.author.sharedDMKey(author),
      ...keystore.ownKeys(),
    ]

    read_key = unboxKey(envelope, feed_id, prev_msg_id, trial_dm_keys, {
      maxAttempts: 16,
    })
```

And the first unboxKey is a bit wasteful if there are no group keys, instead of adding a guard around unboxKey I would rather have this module handle that.