### PR TITLE
Optimize slp encode

### DIFF
--- a/util/derive-secret.js
+++ b/util/derive-secret.js
@@ -6,13 +6,14 @@ const convertBFENilMsg = require('./bfe-nil-msg')
 const hash = 'sha256'
 const hash_len = hkdf.hash_length(hash)
 const key_length = 32
+const bufEnvelope = toBuffer('envelope')
 
 module.exports = function DeriveSecret (feed_id, prev_msg_id) {
   const prevMsgId = convertBFENilMsg(prev_msg_id, feed_id)
 
   return function derive (pk, labels, length = key_length) {
     const info = [
-      toBuffer('envelope'),
+      bufEnvelope,
       feed_id,
       prevMsgId,
       ...(labels.map(toBuffer))

--- a/util/slp-encode.js
+++ b/util/slp-encode.js
@@ -1,13 +1,15 @@
 module.exports = function slpEncode (arr) {
-  let output = Buffer.alloc(0)
+  const length = arr.map(x => 2 + x.length).reduce((sum, x) => sum + x, 0)
+  const output = Buffer.alloc(length)
+  let index = 0
 
   arr.forEach(el => {
     if (!Buffer.isBuffer(el)) throw new Error(`slp.encode expects Buffers, got ${el}`)
 
-    const length = Buffer.alloc(2)
-    length.writeInt16LE(el.length)
-
-    output = Buffer.concat([output, length, el])
+    const len = el.length
+    output.writeInt16LE(len, index)
+    el.copy(output, index + 2)
+    index += 2 + len
   })
 
   return output


### PR DESCRIPTION
I was investigating https://github.com/ssbc/ssb-db2/issues/346 and trying to get an overview of what the difference between box1 and box2 is and if we can do some optimizations. I found that slp encode is rather slow. This optimizes that function to do minimal allocations. 

Before and after benchmark from db2:

```
# private box2 (1 recps)
ok 15 unbox 1000 box2 msgs first run: 180.65ms
ok 16 unbox 1000 box2 msgs second run: 94.69ms
# private box2 group keys (1 key)
ok 19 unbox 1000 box2 group msgs first run: 247.77ms
ok 20 unbox 1000 box2 group msgs second run: 114.02ms

--- after optimizations

# private box2
ok 15 unbox 1000 box2 msgs first run: 161.20ms
ok 16 unbox 1000 box2 msgs second run: 83.33ms
# private box2 group keys
ok 19 unbox 1000 box2 group msgs first run: 222.86ms
ok 20 unbox 1000 box2 group msgs second run: 103.04ms
```